### PR TITLE
Refactor/jsx no bind

### DIFF
--- a/src/components/AddMaterialForm/index.tsx
+++ b/src/components/AddMaterialForm/index.tsx
@@ -1,5 +1,5 @@
-import axios from "axios";
-import { FormEvent, useState, useRef } from "react";
+//import axios from "axios";
+import { FormEvent, useState, useRef, useCallback } from "react";
 
 import { SForm, SDateContainer, SBtnContainer } from "./style";
 
@@ -25,15 +25,11 @@ const FormAddMaterial = () => {
 
   const [isChecked, setIsChecked] = useState<boolean>(false);
 
-  const handleCheckbox = () => {
-    setIsChecked((prev) => !prev);
-  };
+  const handleCheckbox = useCallback(() => setIsChecked((prev) => !prev), []);
 
-  const handleCancel = () => {
-    formRef?.current?.reset();
-  };
+  const handleCancel = useCallback(() => formRef?.current?.reset(), []);
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = useCallback((e: FormEvent) => {
     e.preventDefault();
 
     const formData = new FormData(e.target as HTMLFormElement);
@@ -70,7 +66,7 @@ const FormAddMaterial = () => {
         lifetime_access: ${isChecked}
     `);
     formRef?.current?.reset();
-  };
+  }, []);
 
   return (
     <SForm ref={formRef} onSubmit={handleSubmit}>

--- a/src/components/PrivateContainer/index.tsx
+++ b/src/components/PrivateContainer/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { Outlet } from "react-router-dom";
 import Header from "../Header";
 import Sidebar from "../Sidebar";
@@ -8,13 +8,9 @@ import { Container, ContentSection, Main } from "./style";
 const PrivateContainer = () => {
   const [menuIsActive, setMenuIsActive] = useState(false);
 
-  const toggleToActive = () => {
-    setMenuIsActive(true);
-  };
+  const toggleToActive = useCallback(() => setMenuIsActive(true), []);
 
-  const toggleToDisabled = () => {
-    setMenuIsActive(false);
-  };
+  const toggleToDisabled = useCallback(() => setMenuIsActive(false), []);
 
   return (
     <Container>

--- a/src/pages/ModalPage/index.tsx
+++ b/src/pages/ModalPage/index.tsx
@@ -1,13 +1,15 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import Modal from "../../components/Modal";
 import { Wrapper } from "./style";
 
 const ModalPage = () => {
   const [active, setActive] = useState(false);
 
+  const handleModal = useCallback(() => setActive((curr) => !curr), []);
+
   return (
     <Wrapper>
-      <button onClick={() => setActive(true)}>Abrir Modal</button>
+      <button onClick={handleModal}>Abrir Modal</button>
 
       <Modal
         title="Meta adicionada com sucesso"


### PR DESCRIPTION
Arrow functions envolvidas em useCallback, salvando a referência da função em memória e evitando o re-render.
Isso resolve a regra do eslint (JSX-no-bind).